### PR TITLE
Add support for basic spam detection in Contact Form 7

### DIFF
--- a/includes/comment-invalidation.php
+++ b/includes/comment-invalidation.php
@@ -8,31 +8,12 @@ add_action( 'comment_post', __NAMESPACE__ . '\log_invalid_reasons', 15, 2 );
 add_filter( 'manage_edit-comments_columns', __NAMESPACE__ . '\add_list_table_columns' );
 add_action( 'manage_comments_custom_column', __NAMESPACE__ . '\populate_list_table_columns', 10, 2 );
 
-/**
- * Return the message expected in the comment validator input box.
- */
-function get_valid_message() {
-	return 'Hey. Ignore me while I try to mess with bots. Thanks for commenting!';
-}
 
 /**
  * Add comment fields in an attempt to mess with bot traffic.
  */
 function add_comment_fields() {
-	?>
-	<input name="extremely_important" type="text" style="display:none;" value="<?php echo esc_attr( get_valid_message() ); ?>" />
-	<input id="extremely-empty" name="extremely_empty" type="text" style="display: none;" value="This should arrive empty to get a perfect score!" />
-	<script type="text/Javascript">
-		{
-			// Clear the input that we expect to be empty when the comment is submitted, which
-			// I hope takes actual people longer than 1.5 seconds. If not, then uh... think
-			// before you type just a tiny bit more?
-			setTimeout( function() {
-				document.getElementById( 'extremely-empty' ).setAttribute( 'value', '' );
-			}, 1500 );
-		}
-	</script>
-	<?php
+	echo \SSSS\Common\get_input_markup();
 }
 
 /**
@@ -77,7 +58,7 @@ function get_comment_status( $approved, $commentdata ) {
 		return 'spam';
 	}
 
-	if ( get_valid_message() !== $_POST['extremely_important'] ) {
+	if ( \SSSS\Common\get_valid_message() !== $_POST['extremely_important'] ) {
 		return 'spam';
 	}
 
@@ -104,7 +85,7 @@ function log_invalid_reasons( $comment_id, $approved ) {
 		update_comment_meta( $comment_id, '_ssss_missing_fields', 1 );
 	}
 
-	if ( isset( $_POST['extremely_important'] ) && get_valid_message() !== $_POST['extremely_important'] ) {
+	if ( isset( $_POST['extremely_important'] ) && \SSSS\Common\get_valid_message() !== $_POST['extremely_important'] ) {
 		update_comment_meta( $comment_id, '_ssss_extremely_important_value', sanitize_text_field( $_POST['extremely_important'] ) );
 	}
 

--- a/includes/common.php
+++ b/includes/common.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SSSS\Common;
+
+/**
+ * Return the message expected in the comment validator input box.
+ */
+function get_valid_message() {
+	return 'Hey. Ignore me while I try to mess with bots. Thanks for commenting!';
+}
+
+/**
+ * Return the markup used to represent the hidden inputs that act as honey pots.
+ *
+ * @return string HTML.
+ */
+function get_input_markup() {
+	ob_start();
+	?>
+	<input name="extremely_important" type="text" style="display:none;" value="<?php echo esc_attr( get_valid_message() ); ?>" />
+	<input id="extremely-empty" name="extremely_empty" type="text" style="display: none;" value="This should arrive empty to get a perfect score!" />
+	<script type="text/Javascript">
+		{
+			// Clear the input that we expect to be empty when the comment is submitted, which
+			// I hope takes actual people longer than 1.5 seconds. If not, then uh... think
+			// before you type just a tiny bit more?
+			setTimeout( function() {
+				document.getElementById( 'extremely-empty' ).setAttribute( 'value', '' );
+			}, 1500 );
+		}
+	</script>
+	<?php
+	$markup = ob_get_contents();
+	ob_end_clean();
+
+	return $markup;
+}

--- a/includes/form-invalidation.php
+++ b/includes/form-invalidation.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SSSS\FormInvalidation;
+
+add_action( 'wpcf7_init', __NAMESPACE__ . '\add_ssss_tag', 10 );
+add_filter( 'wpcf7_skip_spam_check', __NAMESPACE__ . '\maybe_check_form', 10, 2 );
+
+/**
+ * Add support for an [ssss] tag to be used in a form that this plugin
+ * should attempt to protect.
+ */
+function add_ssss_tag() {
+	wpcf7_add_form_tag(
+		'ssss',
+		__NAMESPACE__ . '\tag_handler',
+		array(
+			'name'         => 'ssss',
+			'name-attr'    => true,
+			'do-not-store' => true,
+			'not-for-mail' => true,
+		)
+	);
+}
+
+/**
+ * Provide the input markup to inject in place of the [ssss] tag in the
+ * contact form.
+ *
+ * @param \WPCF7_FormTag $tag The current tag being processed.
+ * @return string The HTML markup to display in place of the tag.
+ */
+function tag_handler( $tag ) {
+	if ( 'ssss' !== $tag->type ) {
+		return '';
+	}
+
+	return \SSSS\Common\get_input_markup();
+}
+
+/**
+ * Determine if this form uses the custom [ssss] tag and if it should then
+ * be processed for possible spam by this plugin.
+ *
+ * @param bool              $should_check Untouched.
+ * @param \WPCF7_Submission $submission   The form submission.
+ */
+function maybe_check_form( $should_check, $submission ) {
+
+	$form_tags = wp_list_pluck( $submission->get_contact_form()->scan_form_tags(), 'type' );
+
+	if ( in_array( 'ssss', $form_tags, true ) ) {
+		add_filter( 'wpcf7_spam', __NAMESPACE__ . '\validate_ssss_tag', 10 );
+	}
+
+	return $should_check;
+}
+
+/**
+ * Determine if a submitted message is likely to be spam based on the
+ * contents of the empty and important tags.
+ *
+ * @param bool $spam Whether a spam submission has been detected.
+ * @return bool True if spam. False if not.
+ */
+function validate_ssss_tag( $spam ) {
+	if ( $spam ) {
+		return $spam;
+	}
+
+	if ( ! isset( $_POST['extremely_empty'] ) || ! isset( $_POST['extremely_important'] ) ) {
+		return true;
+	}
+
+	if ( \SSSS\Common\get_valid_message() !== $_POST['extremely_important'] ) {
+		return true;
+	}
+
+	if ( '' !== $_POST['extremely_empty'] ) {
+		return true;
+	}
+
+	return false;
+}

--- a/self-sustaining-spam-stopper.php
+++ b/self-sustaining-spam-stopper.php
@@ -34,4 +34,6 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 	return;
 }
 
+require_once __DIR__ . '/includes/common.php';
 require_once __DIR__ . '/includes/comment-invalidation.php';
+require_once __DIR__ . '/includes/form-invalidation.php';


### PR DESCRIPTION
Adds support for a custom `[ssss]` tag which, when added to a contact form, injects our silly little HTML that attempts to detect bot visits.